### PR TITLE
Refactor Godot project to a multi-page privacy policy website

### DIFF
--- a/Credits.tscn
+++ b/Credits.tscn
@@ -1,0 +1,75 @@
+[gd_scene load_steps=4 format=3 uid="uid://d3v4w5x6y7z8"]
+
+[ext_resource type="Script" path="res://content_page.gd" id="1_abcde"]
+
+[sub_resource type="SystemFont" id="SystemFont_ytr4m"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4hy44"]
+bg_color = Color(0, 0, 0, 1)
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color(0.8, 0, 0, 1)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
+
+[node name="Credits" type="Node2D"]
+script = ExtResource("1_abcde")
+page_url = "https://your-website.com/#credits"
+
+[node name="ColorRect" type="ColorRect" parent="."]
+offset_left = -576.0
+offset_top = -328.0
+offset_right = 576.0
+offset_bottom = 328.0
+color = Color(0, 0, 0, 0.85098)
+
+[node name="Label" type="Label" parent="."]
+offset_left = -500.0
+offset_top = -250.0
+offset_right = 500.0
+offset_bottom = 200.0
+theme_override_colors/font_color = Color(1, 0.883333, 0, 1)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 12
+theme_override_fonts/font = SubResource("SystemFont_ytr4m")
+theme_override_font_sizes/font_size = 22
+autowrap = true
+text = "
+
+all assete were purchased from:
+
+Credit Kenney
+www.kenney.nl
+
+License (Creative Commons Zero, CC0)
+
+any additional art
+mark garrison
+
+dev
+mark garrison
+
+
+producer
+random chaos mechanics studios
+
+contact us
+randomchaosmechanicsstudios@gmail.com
+"
+horizontal_alignment = 1
+
+[node name="CopyLinkButton" type="Button" parent="."]
+offset_left = 376.0
+offset_top = 220.0
+offset_right = 560.0
+offset_bottom = 284.0
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 20
+theme_override_styles/normal = SubResource("StyleBoxFlat_4hy44")
+text = "Copy Link"
+
+[connection signal="pressed" from="CopyLinkButton" to="." method="_on_copy_link_button_pressed"]

--- a/Disclaimer.tscn
+++ b/Disclaimer.tscn
@@ -1,0 +1,71 @@
+[gd_scene load_steps=4 format=3 uid="uid://c2v3w4x5y6z7"]
+
+[ext_resource type="Script" path="res://content_page.gd" id="1_abcde"]
+
+[sub_resource type="SystemFont" id="SystemFont_ytr4m"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4hy44"]
+bg_color = Color(0, 0, 0, 1)
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color(0.8, 0, 0, 1)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
+
+[node name="Disclaimer" type="Node2D"]
+script = ExtResource("1_abcde")
+page_url = "https://your-website.com/#disclaimer"
+
+[node name="ColorRect" type="ColorRect" parent="."]
+offset_left = -576.0
+offset_top = -328.0
+offset_right = 576.0
+offset_bottom = 328.0
+color = Color(0, 0, 0, 0.905882)
+
+[node name="Label" type="Label" parent="."]
+offset_left = -500.0
+offset_top = -250.0
+offset_right = 500.0
+offset_bottom = 200.0
+theme_override_colors/font_color = Color(1, 0.883333, 0, 1)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 12
+theme_override_fonts/font = SubResource("SystemFont_ytr4m")
+theme_override_font_sizes/font_size = 18
+autowrap = true
+text = "
+\"Welcome to Block Hot Agents!
+
+Please Note: This app is a work of satirical parody and is created purely for entertainment and humorous commentary.
+
+Regarding the 'Iceblock' App:
+This app is not created by, associated with, endorsed by, or sponsored by the 'Iceblock' app or its original developers. Any
+ similarities in concept, themes, or appearance are purely for the purpose of satirical commentary
+ on existing applications and their functions.
+ We have not used any code, assets, or proprietary information from the 'Iceblock' app.
+
+Regarding Government Imagery:
+The imagery, seals, or logos that resemble government emblems within this app are entirely fictional and used for satirical effect only.
+ They are not official U.S. Government seals, nor are they affiliated with,
+ endorsed by, or sponsored by the U.S. Government or any of its departments, agencies, or instrumentalities.
+ This app aims to provide social commentary through humor and does not imply any official connection or approval whatsoever.
+
+All content in this app is original work.\"
+"
+
+[node name="CopyLinkButton" type="Button" parent="."]
+offset_left = 376.0
+offset_top = 220.0
+offset_right = 560.0
+offset_bottom = 284.0
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 20
+theme_override_styles/normal = SubResource("StyleBoxFlat_4hy44")
+text = "Copy Link"
+
+[connection signal="pressed" from="CopyLinkButton" to="." method="_on_copy_link_button_pressed"]

--- a/Privacy.tscn
+++ b/Privacy.tscn
@@ -1,0 +1,78 @@
+[gd_scene load_steps=4 format=3 uid="uid://b1v2w3x4y5z6"]
+
+[ext_resource type="Script" path="res://content_page.gd" id="1_abcde"]
+
+[sub_resource type="SystemFont" id="SystemFont_ytr4m"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4hy44"]
+bg_color = Color(0, 0, 0, 1)
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color(0.8, 0, 0, 1)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
+
+[node name="Privacy" type="Node2D"]
+script = ExtResource("1_abcde")
+page_url = "https://your-website.com/#privacy"
+
+[node name="ColorRect" type="ColorRect" parent="."]
+offset_left = -576.0
+offset_top = -328.0
+offset_right = 576.0
+offset_bottom = 328.0
+color = Color(0, 0, 0, 0.941176)
+
+[node name="Label" type="Label" parent="."]
+offset_left = -500.0
+offset_top = -250.0
+offset_right = 500.0
+offset_bottom = 200.0
+theme_override_colors/font_color = Color(1, 0.883333, 0, 1)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 12
+theme_override_fonts/font = SubResource("SystemFont_ytr4m")
+theme_override_font_sizes/font_size = 18
+autowrap = true
+text = "Simple Privacy Block Hot Agents
+Effective Date: July 3, 2025
+This Privacy Policy describes how random chaos mechanics studios handles information in connection with your use of the Block Hot Agents mobile application
+
+We do not collect any personal data from you through this App.
+ * No Personal Information Collected: We do not collect, store, share, or use any personally identifiable information about you, such as your name, email address, location, or device identifiers.
+ * No Usage Data Collected: We do not collect information about how you use the App.
+ * No Data Sharing: Since we do not collect any data, we do not share any data with third parties.
+ * No Cookies or Tracking Technologies: The App does not use cookies, pixels, or other tracking technologies.
+ * Donations: If you choose to make a donation to support the App, this process is handled entirely by the app store's payment processor (e.g., Apple App Store, Google Play Store).
+ We do not receive or store any of your personal financial information related to these transactions.
+Third-Party Services (App Stores):
+Please note that your use of the App is subject to the terms and privacy policies of the platform where you downloaded the App (e.g., Apple App Store, Google Play Store).
+ These platforms may collect certain information, such as device information or purchase history. We have no control over, and assume no responsibility for, the content, privacy policies,
+ or practices of any third-party services.
+Children's Privacy:
+Our App is not directed to children under the age of 13, and we do not knowingly collect personal information from children under 13.
+ If we become aware that we have inadvertently received personal information from a user under the age of 13, we will delete the information from our records.
+Changes to This Privacy Policy:
+We may update our Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy within the App or on our website (if applicable).
+0 You are advised to review this Privacy Policy periodically for any changes.
+Contact Us:
+If you have any questions about this Privacy Policy, please contact us at:
+
+randomchaosmechanicsstudios@gmail.com
+"
+
+[node name="CopyLinkButton" type="Button" parent="."]
+offset_left = 376.0
+offset_top = 220.0
+offset_right = 560.0
+offset_bottom = 284.0
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 20
+theme_override_styles/normal = SubResource("StyleBoxFlat_4hy44")
+text = "Copy Link"
+
+[connection signal="pressed" from="CopyLinkButton" to="." method="_on_copy_link_button_pressed"]

--- a/Privacy2.tscn
+++ b/Privacy2.tscn
@@ -1,0 +1,61 @@
+[gd_scene load_steps=4 format=3 uid="uid://e4v5w6x7y8z9"]
+
+[ext_resource type="Script" path="res://content_page.gd" id="1_abcde"]
+
+[sub_resource type="SystemFont" id="SystemFont_ytr4m"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4hy44"]
+bg_color = Color(0, 0, 0, 1)
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color(0.8, 0, 0, 1)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
+
+[node name="Privacy2" type="Node2D"]
+script = ExtResource("1_abcde")
+page_url = "https://your-website.com/#privacy2"
+
+[node name="ColorRect" type="ColorRect" parent="."]
+offset_left = -576.0
+offset_top = -328.0
+offset_right = 576.0
+offset_bottom = 328.0
+color = Color(0, 0, 0, 0.941176)
+
+[node name="Label" type="Label" parent="."]
+offset_left = -500.0
+offset_top = -250.0
+offset_right = 500.0
+offset_bottom = 200.0
+theme_override_colors/font_color = Color(1, 0.883333, 0, 1)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 12
+theme_override_fonts/font = SubResource("SystemFont_ytr4m")
+theme_override_font_sizes/font_size = 18
+autowrap = true
+text = "Placeholder Privacy Policy 2
+
+This is a placeholder for a future privacy policy.
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+"
+
+[node name="CopyLinkButton" type="Button" parent="."]
+offset_left = 376.0
+offset_top = 220.0
+offset_right = 560.0
+offset_bottom = 284.0
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 20
+theme_override_styles/normal = SubResource("StyleBoxFlat_4hy44")
+text = "Copy Link"
+
+[connection signal="pressed" from="CopyLinkButton" to="." method="_on_copy_link_button_pressed"]

--- a/Privacy3.tscn
+++ b/Privacy3.tscn
@@ -1,0 +1,60 @@
+[gd_scene load_steps=4 format=3 uid="uid://f5v6w7x8y9z0"]
+
+[ext_resource type="Script" path="res://content_page.gd" id="1_abcde"]
+
+[sub_resource type="SystemFont" id="SystemFont_ytr4m"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4hy44"]
+bg_color = Color(0, 0, 0, 1)
+border_width_left = 4
+border_width_top = 4
+border_width_right = 4
+border_width_bottom = 4
+border_color = Color(0.8, 0, 0, 1)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
+
+[node name="Privacy3" type="Node2D"]
+script = ExtResource("1_abcde")
+page_url = "https://your-website.com/#privacy3"
+
+[node name="ColorRect" type="ColorRect" parent="."]
+offset_left = -576.0
+offset_top = -328.0
+offset_right = 576.0
+offset_bottom = 328.0
+color = Color(0, 0, 0, 0.941176)
+
+[node name="Label" type="Label" parent="."]
+offset_left = -500.0
+offset_top = -250.0
+offset_right = 500.0
+offset_bottom = 200.0
+theme_override_colors/font_color = Color(1, 0.883333, 0, 1)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 12
+theme_override_fonts/font = SubResource("SystemFont_ytr4m")
+theme_override_font_sizes/font_size = 18
+autowrap = true
+text = "Placeholder Privacy Policy 3
+
+This is another placeholder for a future privacy policy.
+Cras quis nulla commodo, aliquam lectus sed, blandit augue.
+Cras ullamcorper bibendum bibendum.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+"
+
+[node name="CopyLinkButton" type="Button" parent="."]
+offset_left = 376.0
+offset_top = 220.0
+offset_right = 560.0
+offset_bottom = 284.0
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 20
+theme_override_styles/normal = SubResource("StyleBoxFlat_4hy44")
+text = "Copy Link"
+
+[connection signal="pressed" from="CopyLinkButton" to="." method="_on_copy_link_button_pressed"]

--- a/content_page.gd
+++ b/content_page.gd
@@ -1,0 +1,12 @@
+extends Node2D
+
+export var page_url : String = ""
+
+func _on_copy_link_button_pressed():
+	if JavaScript.is_available():
+		var js_code = "navigator.clipboard.writeText('" + page_url + "');"
+		JavaScript.eval(js_code)
+		print("Attempting to copy to clipboard: " + page_url)
+	else:
+		OS.set_clipboard(page_url)
+		print("Copied to clipboard (desktop): " + page_url)

--- a/menu.gd
+++ b/menu.gd
@@ -1,5 +1,36 @@
 extends Node2D
 
+onready var content_container = $ContentContainer
 
-func _on_exit_prvacy_pressed() -> void:
-	get_tree().quit()
+const PrivacyScene = preload("res://Privacy.tscn")
+const Privacy2Scene = preload("res://Privacy2.tscn")
+const Privacy3Scene = preload("res://Privacy3.tscn")
+const CreditsScene = preload("res://Credits.tscn")
+const DisclaimerScene = preload("res://Disclaimer.tscn")
+
+func _ready():
+	_switch_scene(PrivacyScene)
+
+func _switch_scene(scene):
+	# Clear existing content
+	for child in content_container.get_children():
+		child.queue_free()
+
+	# Instance new scene
+	var new_content = scene.instance()
+	content_container.add_child(new_content)
+
+func _on_privacy_button_pressed():
+	_switch_scene(PrivacyScene)
+
+func _on_privacy2_button_pressed():
+	_switch_scene(Privacy2Scene)
+
+func _on_privacy3_button_pressed():
+	_switch_scene(Privacy3Scene)
+
+func _on_credits_button_pressed():
+	_switch_scene(CreditsScene)
+
+func _on_disclaimer_button_pressed():
+	_switch_scene(DisclaimerScene)

--- a/menu.tscn
+++ b/menu.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3 uid="uid://dtn38bp02dijs"]
 
-[sub_resource type="SystemFont" id="SystemFont_ytr4m"]
+[ext_resource type="Script" path="res://menu.gd" id="1_flick"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4hy44"]
 bg_color = Color(0, 0, 0, 1)
@@ -15,172 +15,63 @@ corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 
 [node name="menu" type="Node2D"]
+script = ExtResource("1_flick")
 
 [node name="Camera2D" type="Camera2D" parent="."]
 
-[node name="credits" type="Node2D" parent="."]
-visible = false
-z_index = 71
+[node name="Navigation" type="Node2D" parent="."]
+z_index = 100
 
-[node name="ColorRect" type="ColorRect" parent="credits"]
-offset_left = -576.0
-offset_top = -328.0
-offset_right = 576.0
-offset_bottom = 328.0
-color = Color(0, 0, 0, 0.85098)
-
-[node name="Label" type="Label" parent="credits"]
-offset_left = -568.0
+[node name="PrivacyButton" type="Button" parent="Navigation"]
+offset_left = -570.0
 offset_top = -320.0
-offset_right = 531.0
-offset_bottom = 190.0
-theme_override_colors/font_color = Color(1, 0.883333, 0, 1)
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 12
-theme_override_fonts/font = SubResource("SystemFont_ytr4m")
-theme_override_font_sizes/font_size = 17
-text = "
+offset_right = -410.0
+offset_bottom = -260.0
+theme_override_font_sizes/font_size = 20
+theme_override_styles/normal = SubResource("StyleBoxFlat_4hy44")
+text = "Privacy"
 
-all assete were purchased from:
-
-Credit Kenney 
-www.kenney.nl
-
-License (Creative Commons Zero, CC0)
-
-any additional art
-mark garrison
-
-dev 
-mark garrison
-
-
-producer
-random chaos mechanics studios
-
-contact us 
-randomchaosmechanicsstudios@gmail.com
-"
-horizontal_alignment = 1
-
-[node name="exit_credits" type="Button" parent="credits"]
-offset_left = 384.0
+[node name="Privacy2Button" type="Button" parent="Navigation"]
+offset_left = -400.0
 offset_top = -320.0
-offset_right = 568.0
-offset_bottom = -256.0
-theme_override_colors/font_color = Color(1, 0, 0, 1)
-theme_override_font_sizes/font_size = 40
+offset_right = -240.0
+offset_bottom = -260.0
+theme_override_font_sizes/font_size = 20
 theme_override_styles/normal = SubResource("StyleBoxFlat_4hy44")
-text = "exit"
+text = "Privacy 2"
 
-[node name="Privacy" type="Node2D" parent="."]
-z_index = 72
-
-[node name="ColorRect" type="ColorRect" parent="Privacy"]
-offset_left = -576.0
-offset_top = -328.0
-offset_right = 576.0
-offset_bottom = 328.0
-color = Color(0, 0, 0, 0.941176)
-
-[node name="Label" type="Label" parent="Privacy"]
-offset_left = -568.0
-offset_top = -312.0
-offset_right = 539.0
-offset_bottom = 205.0
-theme_override_colors/font_color = Color(1, 0.883333, 0, 1)
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 12
-theme_override_fonts/font = SubResource("SystemFont_ytr4m")
-theme_override_font_sizes/font_size = 12
-text = "Simple Privacy Block Hot Agents
-Effective Date: July 3, 2025
-This Privacy Policy describes how random chaos mechanics studios handles information in connection with your use of the Block Hot Agents mobile application
-
-We do not collect any personal data from you through this App.
- * No Personal Information Collected: We do not collect, store, share, or use any personally identifiable information about you, such as your name, email address, location, or device identifiers.
- * No Usage Data Collected: We do not collect information about how you use the App.
- * No Data Sharing: Since we do not collect any data, we do not share any data with third parties.
- * No Cookies or Tracking Technologies: The App does not use cookies, pixels, or other tracking technologies.
- * Donations: If you choose to make a donation to support the App, this process is handled entirely by the app store's payment processor (e.g., Apple App Store, Google Play Store).
- We do not receive or store any of your personal financial information related to these transactions.
-Third-Party Services (App Stores):
-Please note that your use of the App is subject to the terms and privacy policies of the platform where you downloaded the App (e.g., Apple App Store, Google Play Store).
- These platforms may collect certain information, such as device information or purchase history. We have no control over, and assume no responsibility for, the content, privacy policies,
- or practices of any third-party services.
-Children's Privacy:
-Our App is not directed to children under the age of 13, and we do not knowingly collect personal information from children under 13.
- If we become aware that we have inadvertently received personal information from a user under the age of 13, we will delete the information from our records.
-Changes to This Privacy Policy:
-We may update our Privacy Policy from time to time. We will notify you of any changes by posting the new Privacy Policy within the App or on our website (if applicable).
-0 You are advised to review this Privacy Policy periodically for any changes.
-Contact Us:
-If you have any questions about this Privacy Policy, please contact us at:
-
-randomchaosmechanicsstudios@gmail.com
-"
-
-[node name="exit_prvacy" type="Button" parent="Privacy"]
-offset_left = 376.0
-offset_top = 136.0
-offset_right = 560.0
-offset_bottom = 200.0
-theme_override_colors/font_color = Color(1, 0, 0, 1)
-theme_override_font_sizes/font_size = 40
-theme_override_styles/normal = SubResource("StyleBoxFlat_4hy44")
-text = "exit"
-
-[node name="disclaimer" type="Node2D" parent="."]
-visible = false
-z_index = 73
-
-[node name="ColorRect" type="ColorRect" parent="disclaimer"]
-offset_left = -576.0
-offset_top = -328.0
-offset_right = 576.0
-offset_bottom = 328.0
-color = Color(0, 0, 0, 0.905882)
-
-[node name="Label" type="Label" parent="disclaimer"]
-offset_left = -568.0
+[node name="Privacy3Button" type="Button" parent="Navigation"]
+offset_left = -230.0
 offset_top = -320.0
-offset_right = 531.0
-offset_bottom = 190.0
-theme_override_colors/font_color = Color(1, 0.883333, 0, 1)
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 12
-theme_override_fonts/font = SubResource("SystemFont_ytr4m")
-theme_override_font_sizes/font_size = 17
-text = "
-\"Welcome to Block Hot Agents!
-
-Please Note: This app is a work of satirical parody and is created purely for entertainment and humorous commentary.
-
-Regarding the 'Iceblock' App:
-This app is not created by, associated with, endorsed by, or sponsored by the 'Iceblock' app or its original developers. Any 
- similarities in concept, themes, or appearance are purely for the purpose of satirical commentary
- on existing applications and their functions.
- We have not used any code, assets, or proprietary information from the 'Iceblock' app.
-
-Regarding Government Imagery:
-The imagery, seals, or logos that resemble government emblems within this app are entirely fictional and used for satirical effect only.
- They are not official U.S. Government seals, nor are they affiliated with,
- endorsed by, or sponsored by the U.S. Government or any of its departments, agencies, or instrumentalities.
- This app aims to provide social commentary through humor and does not imply any official connection or approval whatsoever.
-
-All content in this app is original work.\"
-"
-
-[node name="exit_disclaimer" type="Button" parent="disclaimer"]
-offset_left = 200.0
-offset_top = -312.0
-offset_right = 384.0
-offset_bottom = -248.0
-theme_override_colors/font_color = Color(1, 0, 0, 1)
-theme_override_font_sizes/font_size = 40
+offset_right = -70.0
+offset_bottom = -260.0
+theme_override_font_sizes/font_size = 20
 theme_override_styles/normal = SubResource("StyleBoxFlat_4hy44")
-text = "exit"
+text = "Privacy 3"
 
-[connection signal="pressed" from="credits/exit_credits" to="." method="_on_exit_credits_pressed"]
-[connection signal="pressed" from="Privacy/exit_prvacy" to="." method="_on_exit_prvacy_pressed"]
-[connection signal="pressed" from="disclaimer/exit_disclaimer" to="." method="_on_exit_disclaimer_pressed"]
+[node name="CreditsButton" type="Button" parent="Navigation"]
+offset_left = -60.0
+offset_top = -320.0
+offset_right = 100.0
+offset_bottom = -260.0
+theme_override_font_sizes/font_size = 20
+theme_override_styles/normal = SubResource("StyleBoxFlat_4hy44")
+text = "Credits"
+
+[node name="DisclaimerButton" type="Button" parent="Navigation"]
+offset_left = 110.0
+offset_top = -320.0
+offset_right = 270.0
+offset_bottom = -260.0
+theme_override_font_sizes/font_size = 20
+theme_override_styles/normal = SubResource("StyleBoxFlat_4hy44")
+text = "Disclaimer"
+
+[node name="ContentContainer" type="Node2D" parent="."]
+position = Vector2(0, 50)
+
+[connection signal="pressed" from="Navigation/PrivacyButton" to="." method="_on_privacy_button_pressed"]
+[connection signal="pressed" from="Navigation/Privacy2Button" to="." method="_on_privacy2_button_pressed"]
+[connection signal="pressed" from="Navigation/Privacy3Button" to="." method="_on_privacy3_button_pressed"]
+[connection signal="pressed" from="Navigation/CreditsButton" to="." method="_on_credits_button_pressed"]
+[connection signal="pressed" from="Navigation/DisclaimerButton" to="." method="_on_disclaimer_button_pressed"]

--- a/privacy-policy/.editorconfig
+++ b/privacy-policy/.editorconfig
@@ -1,4 +1,0 @@
-root = true
-
-[*]
-charset = utf-8


### PR DESCRIPTION
This commit refactors the Godot project from a single-scene application to a multi-page website, as per the user's request.

The main changes include:
- Breaking down the monolithic `menu.tscn` into separate scenes for each page (Privacy, Disclaimer, Credits, and two placeholder privacy pages).
- Implementing a navigation bar in `menu.tscn` to switch between the different content scenes.
- Creating a `content_page.gd` script to handle a "Copy Link" feature, which copies the page's URL to the clipboard using JavaScript for web compatibility.
- Increasing the font sizes and adjusting the layout to improve readability.
- Removing an unused `privacy-policy` directory.